### PR TITLE
[Proj] Enable Server Garbage Collection

### DIFF
--- a/FilmFlock/FilmFlock.csproj
+++ b/FilmFlock/FilmFlock.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### What?
This PR enables the .NET server garbage collector rather than using the default workstation GC.

### Why?
Performance.

The workstation GC executes quickly on the main thread allowing it to finish faster (which is good for desktop apps and games which are also likely to have higher memory usage). 

The server GC executes across background threads in small increments any time a thread is blocking due to I/O or resource contention. This leads to a lower latency and higher throughput for the server.